### PR TITLE
Fix: .coveragerc now does not test core/__init__.py

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,8 +2,10 @@
 omit =
     */venv/*
     */tests/*
+    core/__init__.py
 
 [report]
 omit =
     */venv/*
     */tests/*
+    core/__init__.py


### PR DESCRIPTION
Closes #35 